### PR TITLE
fix: refresh token cookie name mismatch

### DIFF
--- a/src/main/java/api/auth/AuthController.java
+++ b/src/main/java/api/auth/AuthController.java
@@ -92,7 +92,7 @@ public class AuthController {
         Cookie[] cookies = request.getCookies();
 
         for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("refresh")) {
+            if (cookie.getName().equals("Refresh")) {
                 refresh = cookie.getValue();
             }
         }
@@ -131,7 +131,7 @@ public class AuthController {
         addRefreshEntity(email, newRefresh, 86400000L);
 
         response.setHeader("access", newAccess);
-        response.addCookie(createCookie("refresh", newRefresh));
+        response.addCookie(createCookie("Refresh", newRefresh));
 
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/api/auth/filter/CustomLogoutFilter.java
+++ b/src/main/java/api/auth/filter/CustomLogoutFilter.java
@@ -44,7 +44,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                if ("refresh".equals(cookie.getName())) {
+                if ("Refresh".equals(cookie.getName())) {
                     refresh = cookie.getValue();
                 }
             }
@@ -69,7 +69,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
         }
 
         refreshRepository.deleteByRefresh(refresh);
-        Cookie cookie = new Cookie("refresh", null);
+        Cookie cookie = new Cookie("Refresh", null);
         cookie.setMaxAge(0);
         cookie.setPath("/");
         response.addCookie(cookie);


### PR DESCRIPTION
리프레시 토큰을 쿠키에 저장하거나 불러올 때 쿠키 이름을 "refresh"와 "Refresh" 두 가지로 사용하여 오류가 발생하는 것을 해결했습니다.
쿠키에 접근하는 부분 외에 "refresh" 문자열은 수정하지 않았습니다.